### PR TITLE
Use mempool.js as backend

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@catalabs/mempool.js": "^2.3.3",
     "axios": "^1.6.7",
     "dotenv": "^16.4.5"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,62 +1,54 @@
-lockfileVersion: '6.0'
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-dependencies:
-  axios:
-    specifier: ^1.6.7
-    version: 1.6.7
-  dotenv:
-    specifier: ^16.4.5
-    version: 16.4.5
+importers:
 
-devDependencies:
-  '@types/node':
-    specifier: ^20.11.20
-    version: 20.11.20
+  .:
+    dependencies:
+      '@catalabs/mempool.js':
+        specifier: ^2.3.3
+        version: 2.3.3
+      axios:
+        specifier: ^1.6.7
+        version: 1.6.7
+      dotenv:
+        specifier: ^16.4.5
+        version: 16.4.5
+    devDependencies:
+      '@types/node':
+        specifier: ^20.11.20
+        version: 20.11.20
 
 packages:
 
-  /@types/node@20.11.20:
+  '@catalabs/mempool.js@2.3.3':
+    resolution: {integrity: sha512-PR1XoKT+6jPTtA2Zs50PfZkd/pxK5cfk9HZ7diJQeKGoxK4jGbUHvH0sO5PjpUIhLbKQtjQetZthSTdnmTzRBQ==}
+
+  '@types/node@20.11.20':
     resolution: {integrity: sha512-7/rR21OS+fq8IyHTgtLkDK949uzsa6n8BkziAKtPVpugIkO6D+/ooXMvzXxDnZrmtXVfjb1bKQafYpb8s89LOg==}
-    dependencies:
-      undici-types: 5.26.5
-    dev: true
 
-  /asynckit@0.4.0:
+  asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
-    dev: false
 
-  /axios@1.6.7:
+  axios@1.6.7:
     resolution: {integrity: sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==}
-    dependencies:
-      follow-redirects: 1.15.5
-      form-data: 4.0.0
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
-    dev: false
 
-  /combined-stream@1.0.8:
+  combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
-    dependencies:
-      delayed-stream: 1.0.0
-    dev: false
 
-  /delayed-stream@1.0.0:
+  delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
-    dev: false
 
-  /dotenv@16.4.5:
+  dotenv@16.4.5:
     resolution: {integrity: sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==}
     engines: {node: '>=12'}
-    dev: false
 
-  /follow-redirects@1.15.5:
+  follow-redirects@1.15.5:
     resolution: {integrity: sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==}
     engines: {node: '>=4.0'}
     peerDependencies:
@@ -64,33 +56,86 @@ packages:
     peerDependenciesMeta:
       debug:
         optional: true
-    dev: false
 
-  /form-data@4.0.0:
+  form-data@4.0.0:
     resolution: {integrity: sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==}
     engines: {node: '>= 6'}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+
+  undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+
+  ws@8.3.0:
+    resolution: {integrity: sha512-Gs5EZtpqZzLvmIM59w4igITU57lrtYVFneaa434VROv4thzJyV6UjIL3D42lslWlI+D4KzLYnxSwtfuiO79sNw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: ^5.0.2
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+snapshots:
+
+  '@catalabs/mempool.js@2.3.3':
+    dependencies:
+      axios: 1.6.7
+      ws: 8.3.0
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - utf-8-validate
+
+  '@types/node@20.11.20':
+    dependencies:
+      undici-types: 5.26.5
+
+  asynckit@0.4.0: {}
+
+  axios@1.6.7:
+    dependencies:
+      follow-redirects: 1.15.5
+      form-data: 4.0.0
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
+
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
+  delayed-stream@1.0.0: {}
+
+  dotenv@16.4.5: {}
+
+  follow-redirects@1.15.5: {}
+
+  form-data@4.0.0:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       mime-types: 2.1.35
-    dev: false
 
-  /mime-db@1.52.0:
-    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
-    engines: {node: '>= 0.6'}
-    dev: false
+  mime-db@1.52.0: {}
 
-  /mime-types@2.1.35:
-    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
-    engines: {node: '>= 0.6'}
+  mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
-    dev: false
 
-  /proxy-from-env@1.1.0:
-    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
-    dev: false
+  proxy-from-env@1.1.0: {}
 
-  /undici-types@5.26.5:
-    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
-    dev: true
+  undici-types@5.26.5: {}
+
+  ws@8.3.0: {}

--- a/src/examples/test.ts
+++ b/src/examples/test.ts
@@ -1,22 +1,5 @@
-import {
-  generateProof,
-  getBtcBlockHash,
-  getBtcBlock,
-  generateBlockHeader,
-} from "../getProof";
+import { generateBlockHeaders, generateProof } from "../getProof";
 
-const txid = "3836352218be851ebb4685d7f3a22dde70a66b52a965e62c2a0bfa0988cdd0ba";
-
-generateProof(txid).then((val) => console.log(val));
-
-// getBtcBlockHash(717696).then((blockhash) =>
-//   getBtcBlock(blockhash).then((block) =>
-//     console.log(generateBlockHeader(block)),
-//   ),
-// );
-
-// getBtcBlockHash(717697).then((blockhash) =>
-//   getBtcBlock(blockhash).then((block) =>
-//     console.log(generateBlockHeader(block)),
-//   ),
-// );
+generateProof(
+  "dbf25501225cbf5d7cbff3be5da158982c4cda87bc917c0678885f07cde51caf",
+).then((result) => console.log(result));

--- a/src/getProof.ts
+++ b/src/getProof.ts
@@ -6,6 +6,7 @@ const {
   bitcoin: { transactions, blocks },
 } = mempoolJS({
   hostname: "mempool.space",
+  network: TESTNET ? "testnet4" : undefined,
 });
 
 import type { Block, Proof } from "./types";
@@ -118,7 +119,7 @@ export async function generateBlockHeaders(
   };
 }
 
-// TODO: fix
-export function getExpectedTarget(block: Block) {
-  return "0x" + block.bits.slice(3).padEnd(45, "0").padStart(64, "0");
+export function getExpectedTarget(block: { bits: number }) {
+  const hexBits = block.bits.toString(16);
+  return "0x" + hexBits.slice(3).padEnd(45, "0").padStart(64, "0");
 }

--- a/src/getProof.ts
+++ b/src/getProof.ts
@@ -1,6 +1,4 @@
-import axios from "axios";
 import "dotenv/config";
-import { getProof } from "./lib/bitcoin-proof";
 import mempoolJS from "@catalabs/mempool.js";
 
 const TESTNET = process.env.TESTNET;
@@ -34,11 +32,12 @@ export async function generateProof(
 
   const merkleProof = await transactions.getTxMerkleProof({ txid });
   // TODO: serialisation version 1.
-  const rawTx = await transactions.getTxRaw({ txid });
+  const rawTx = await transactions.getTxHex({ txid });
 
   const blockHash = await blocks.getBlockHeight({
     height: merkleProof.block_height,
   });
+  console.log(rawTx);
   // const block = await blocks.getBlock({ hash: blockHash });
 
   // const blockHeader = generateBlockHeader(block);
@@ -50,6 +49,9 @@ export async function generateProof(
       txId: txid,
       txIndex: merkleProof.pos,
       sibling: merkleProof.merkle,
+      concatedSiblings: merkleProof.merkle.reduce(
+        (accumulator, currentValue) => accumulator + currentValue,
+      ),
     },
     rawTx,
   };
@@ -116,6 +118,7 @@ export async function generateBlockHeaders(
   };
 }
 
+// TODO: fix
 export function getExpectedTarget(block: Block) {
   return "0x" + block.bits.slice(3).padEnd(45, "0").padStart(64, "0");
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,39 +20,9 @@ export type Block = {
   tx: string[];
 };
 
-export type Input = {
-  txid: string;
-  vout: number;
-  scriptSig: any;
-  txinwitness: any;
-  sequence: number;
-};
-
-export type Output = {
-  value: number;
-  n: number;
-  scriptPubKey: any;
-};
-
-export type Transaction = {
-  txid: string;
-  hash: string;
-  version: number;
-  size: number;
-  vsize: number;
-  weight: number;
-  locktime: number;
-  vin: Input[];
-  vout: Output[];
-  hex: string;
-  blockhash: string;
-  confirmations: number;
-  time: number;
-  blocktime: number;
-};
-
 export type Proof = {
   txId: string;
   txIndex: number;
   sibling: string[];
+  concatedSiblings: string;
 };


### PR DESCRIPTION
This implement all functionality of the old library except `getExpectedTarget`. Additionally, the prooflib is actually not used anymore since mempool.js can handle the majority of the tasks itself.